### PR TITLE
Fixed : Custom Auto-Labeling Workflow for GitHub

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -22,28 +22,28 @@ jobs:
             const hasGSSOC = issueBody.includes('gssoc');
             const hasHacktoberfest = issueBody.includes('hacktoberfest');
 
+            const labelsToAdd = [];
+
+            // Add labels based on participation roles
             if (hasGSSOC) {
-              // Add gssoc label for GSSOC participants
+              labelsToAdd.push('gssoc-ext');
+              console.log('gssoc-ext label will be added for GSSOC participant.');
+            }
+
+            if (hasHacktoberfest) {
+              labelsToAdd.push('hacktoberfest-accepted');
+              console.log('hacktoberfest-accepted label will be added for Hacktoberfest participant.');
+            }
+
+            // Add labels if any are present
+            if (labelsToAdd.length > 0) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['gssoc-ext']
+                labels: labelsToAdd
               });
-              console.log('Added gssoc-ext label for GSSOC participant.');
-            }
-
-            if (hasHacktoberfest && !hasGSSOC) {
-              // Add hacktoberfest label for Hacktoberfest participants
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                labels: ['hacktoberfest-accepted']
-              });
-              console.log('Added hacktoberfest-accepted label for Hacktoberfest participant.');
-            }
-
-            if (!hasGSSOC && !hasHacktoberfest) {
+              console.log(`Added labels: ${labelsToAdd.join(', ')}`);
+            } else {
               console.log('No relevant participation role found. Skipping label addition.');
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -17,17 +17,33 @@ jobs:
           script: |
             const issue = context.payload.issue;
             const issueBody = issue.body ? issue.body.toLowerCase() : '';
-            const issueTitle = issue.title.toLowerCase();
-            
-            // Check if the issue body mentions GSSOC
-            if (issueBody.includes('gssoc')) {
-              // Add gssoc label to issues that mention GSSOC
+
+            // Check for participation roles in the issue body
+            const hasGSSOC = issueBody.includes('gssoc');
+            const hasHacktoberfest = issueBody.includes('hacktoberfest');
+
+            if (hasGSSOC) {
+              // Add gssoc label for GSSOC participants
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
-                labels: ['gssoc-ext', 'hacktoberfest-accepted']
+                labels: ['gssoc-ext']
               });
-            } else {
-              console.log('No GSSOC mention found. Skipping label addition.');
+              console.log('Added gssoc-ext label for GSSOC participant.');
+            }
+
+            if (hasHacktoberfest && !hasGSSOC) {
+              // Add hacktoberfest label for Hacktoberfest participants
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['hacktoberfest-accepted']
+              });
+              console.log('Added hacktoberfest-accepted label for Hacktoberfest participant.');
+            }
+
+            if (!hasGSSOC && !hasHacktoberfest) {
+              console.log('No relevant participation role found. Skipping label addition.');
             }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,33 @@
+name: Auto Label Issue
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Label Issue
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const issueBody = issue.body ? issue.body.toLowerCase() : '';
+            const issueTitle = issue.title.toLowerCase();
+            
+            // Check if the issue body mentions GSSOC
+            if (issueBody.includes('gssoc')) {
+              // Add gssoc label to issues that mention GSSOC
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['gssoc-ext', 'hacktoberfest-accepted']
+              });
+            } else {
+              console.log('No GSSOC mention found. Skipping label addition.');
+            }


### PR DESCRIPTION
## Pull Request for PyVerse 💡
Fixed #259 
### Requesting to submit a pull request to the PyVerse repository.

---

#### Issue Title
**Please enter the title of the issue related to your pull request.**  
*Enter the issue title here.*


---
Auto-Labeling Workflow for GitHub
#### Info about the Related Issue
Here's a suggested description for your pull request (PR) related to the auto-labeling workflow:

---

### Pull Request Description

**Title:** Implement Auto-Labeling Workflow for GitHub Issues

**Description:**

This pull request introduces an automated labeling workflow for GitHub issues. The workflow checks the issue body for mentions of participation roles and applies appropriate labels based on the contributor's involvement in specific open-source programs.

**Key Features:**

- **Automatic Labeling:** The workflow automatically adds labels to issues when they are opened, reopened, or edited.
- **Participation Role Detection:** It checks for the following roles:
  - If the issue body contains "GSSOC", the label `gssoc-ext` is added.
  - If the issue body contains "Hacktoberfest", the label `hacktoberfest-accepted` is added.
  - If both roles are mentioned, both labels are applied.
- **Console Logging:** Clear logs are provided to indicate which labels are being added or if no relevant roles are found.

**Benefits:**
- Enhances contributor engagement by clearly marking contributions based on their participation roles.
- Streamlines the labeling process, reducing manual effort for maintainers.
- Provides visibility into contributions for both GSSOC and Hacktoberfest participants.


#### Checklist
**Please confirm the following:**  
- [X] My code follows the guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly wherever it was hard to understand.
- [X] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [X] I have added things that prove my fix is effective or that my feature works.
- [X] Any dependent changes have been merged and published in downstream modules.
