### PR TITLE
✨ Add CLI Pomodoro Timer under Beginner Projects

### DIFF
--- a/Beginner_Projects/pomodoro_timer.py
+++ b/Beginner_Projects/pomodoro_timer.py
@@ -1,0 +1,50 @@
+import time
+from datetime import datetime
+
+# Constants
+FOCUS_DURATION = 25 * 60     # 25 minutes
+SHORT_BREAK = 5 * 60         # 5 minutes
+LONG_BREAK = 15 * 60         # 15 minutes
+SESSIONS_BEFORE_LONG_BREAK = 4
+LOG_FILE = "pomodoro_log.txt"
+
+def log_session(message):
+    with open(LOG_FILE, "a") as file:
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        file.write(f"[{timestamp}] {message}\n")
+
+def countdown(seconds, label):
+    print(f"\n⏱️ {label} started for {seconds // 60} minutes.")
+    while seconds:
+        mins, secs = divmod(seconds, 60)
+        time_str = f"{mins:02d}:{secs:02d}"
+        print(f"\r{label}: {time_str}", end="")
+        time.sleep(1)
+        seconds -= 1
+    print(f"\n✅ {label} completed!")
+    log_session(f"{label} completed.")
+
+def pomodoro_timer():
+    pomodoros_completed = 0
+
+    while True:
+        countdown(FOCUS_DURATION, "Focus Session")
+        pomodoros_completed += 1
+        print(f"🎯 Pomodoros completed: {pomodoros_completed}")
+        log_session(f"Pomodoros completed so far: {pomodoros_completed}")
+
+        if pomodoros_completed % SESSIONS_BEFORE_LONG_BREAK == 0:
+            countdown(LONG_BREAK, "Long Break")
+        else:
+            countdown(SHORT_BREAK, "Short Break")
+
+        # Ask user if they want to continue
+        cont = input("Start next session? (y/n): ").strip().lower()
+        if cont != 'y':
+            log_session("Pomodoro session ended by user.\n")
+            print("👋 Goodbye! Stay productive!")
+            break
+
+if __name__ == "__main__":
+    print("🍅 Welcome to the CLI Pomodoro Timer")
+    pomodoro_timer()


### PR DESCRIPTION
## 📝 Description

This PR adds a beginner-friendly **Command-Line Pomodoro Timer** written in Python. It is designed to help users manage their focus sessions and breaks using the Pomodoro Technique — all directly from the terminal.

The script uses only Python’s standard library and is ideal for beginners learning about:
- Time-based logic
- Terminal input/output
- Basic session tracking
- File handling and logging

## 🎯 Features

- ✅ 25-minute focus sessions
- ☕ 5-minute short breaks
- 💤 15-minute long break after every 4 focus sessions
- 🔔 Terminal-based countdown and text-based alerts
- 🧠 Tracks number of Pomodoros completed in a run
- 📝 Logs session activity to a `pomodoro_log.txt` file with timestamps

## 📁 File Added

- `Beginner_Projects/pomodoro_timer.py`

## 📌 Issue Reference

Fixes #1301
ARYA RAI
@awrya-cmd 

#1301 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line Pomodoro timer that manages focus and break intervals.
  * Displays a live countdown for each session and break.
  * Logs session events with timestamps to a log file.
  * Prompts users to continue or end sessions after each break.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->