### PR TITLE
Remove breaking gitattribute

### DIFF
--- a/Deep_Learning/Speech_Emotion_Recognition/.gitattributes
+++ b/Deep_Learning/Speech_Emotion_Recognition/.gitattributes
@@ -1,2 +1,0 @@
-training_p.ipynb filter=lfs diff=lfs merge=lfs -text
-Emotion_Voice_Detection_Model.pkl filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
A .gitattribute was added in one of the projects and it was doing breaking changes in the project. Everytime one needed to uninstall lfs to make even normal commits. Please merge as lfs is not required for files as small as 2MB.

<img width="928" height="935" alt="image" src="https://github.com/user-attachments/assets/4b9d6572-e2a5-4381-b016-4b8447eef595" />
